### PR TITLE
Minor bug on Sepsis dataset download

### DIFF
--- a/tableshift/core/data_source.py
+++ b/tableshift/core/data_source.py
@@ -521,7 +521,7 @@ class PhysioNetDataSource(DataSource):
                          "take several minutes.")
             # download the training data
             cmd = "wget -r -N -c -np https://physionet.org/files/challenge" \
-                  f"-2019/1.0.0/training/ -P={self.cache_dir}"
+                  f"-2019/1.0.0/training/ -P {self.cache_dir}"
             utils.run_in_subprocess(cmd)
         else:
             logging.info(f"detected valid physionet training data at {root}; "


### PR DESCRIPTION
Hi,

When running `get_dataset("physionet")`, it seems the `PhysioNetDataSource` is downloaded to the folder `"=tmp"` instead of `"tmp"`.

See the difference in the save folders in the following before and after prints:

**Before:**
<img width="833" alt="Screen Shot 2023-10-18 at 13 05 33" src="https://github.com/mlfoundations/tableshift/assets/13498941/4650884e-ef9b-4f56-aee0-d2e9800a1cd0">

**After:**
Now with minor code change it prints:
<img width="830" alt="Screen Shot 2023-10-18 at 13 05 46" src="https://github.com/mlfoundations/tableshift/assets/13498941/baf00a61-8a95-42cc-bd21-05196b86ff86">


This was ran using the recommended docker container method.

